### PR TITLE
Update accent colors to yellow (#FACC15)

### DIFF
--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -246,7 +246,7 @@
   }
 
   .social-link:hover i {
-    color: #680840 !important;
+    color: #FACC15 !important;
   }
 
   /* Cookie Notice Styles */
@@ -270,7 +270,7 @@
   }
 
   .learn-more-link:hover {
-    color: #680840;
+    color: #FACC15;
   }
 
   /* Cookie Popup Styles */

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -246,7 +246,7 @@
   }
 
   .social-link:hover i {
-    color: #7c3aed !important;
+    color: #300030 !important;
   }
 
   /* Cookie Notice Styles */
@@ -270,7 +270,7 @@
   }
 
   .learn-more-link:hover {
-    color: #7c3aed;
+    color: #300030;
   }
 
   /* Cookie Popup Styles */

--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -246,7 +246,7 @@
   }
 
   .social-link:hover i {
-    color: #300030 !important;
+    color: #680840 !important;
   }
 
   /* Cookie Notice Styles */
@@ -270,7 +270,7 @@
   }
 
   .learn-more-link:hover {
-    color: #300030;
+    color: #680840;
   }
 
   /* Cookie Popup Styles */

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,8 +14,8 @@ module.exports = {
           'bg': '#000000',
           'text-primary': '#ffffff',
           'text-secondary': '#cccccc',
-          'accent': '#7c3aed',
-          'accent-hover': '#8b5cf6',
+          'accent': '#300030',
+          'accent-hover': '#300030',
         },
         'teal': {
           300: 'rgba(50, 184, 198, 1)',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,8 +14,8 @@ module.exports = {
           'bg': '#000000',
           'text-primary': '#ffffff',
           'text-secondary': '#cccccc',
-          'accent': '#300030',
-          'accent-hover': '#300030',
+          'accent': '#680840',
+          'accent-hover': '#680840',
         },
         'teal': {
           300: 'rgba(50, 184, 198, 1)',

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,8 +14,8 @@ module.exports = {
           'bg': '#000000',
           'text-primary': '#ffffff',
           'text-secondary': '#cccccc',
-          'accent': '#680840',
-          'accent-hover': '#680840',
+          'accent': '#FACC15',
+          'accent-hover': '#FACC15',
         },
         'teal': {
           300: 'rgba(50, 184, 198, 1)',


### PR DESCRIPTION
## Purpose
The user requested to update the accent color scheme after testing multiple color options. They initially wanted to replace the existing accent colors with #300030, then changed to #680840, and finally settled on #FACC15 (yellow) as the preferred accent color for the application.

## Code changes
- Updated accent color from `#7c3aed` (purple) to `#FACC15` (yellow) in Tailwind config
- Updated accent-hover color from `#8b5cf6` to `#FACC15` (same as accent color)
- Updated social link hover color in CSS from `#7c3aed` to `#FACC15`
- Updated learn-more-link hover color from `#7c3aed` to `#FACC15`

This change provides a consistent yellow accent color throughout the application's UI elements and hover states.

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 4`

🔗 [Edit in Builder.io](https://builder.io/app/projects/d83244c1084e42af896a909f4e85ab24/stellar-zone)

👀 [Preview Link](https://d83244c1084e42af896a909f4e85ab24-stellar-zone.projects.builder.my/)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>d83244c1084e42af896a909f4e85ab24</projectId>-->
<!--<branchName>stellar-zone</branchName>-->